### PR TITLE
refactor: move API keys to environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
 .DS_Store
 # vendor/
-*.out
-*prod*
-*debug*
-*.db
-*.secret
+.env

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
-BOT_TOKEN=$(shell cat bottoken.secret)
-OPENAI_API_KEY=$(shell cat openaiapikey.secret)
-BOT_USERS=$(shell cat botusers.secret)
+include .env
+
+.PHONY: run tests docker
+
+run:
+	BOT_TOKEN=$(BOT_TOKEN) OPENAI_API_KEY=$(OPENAI_API_KEY) BOT_USERS=$(BOT_USERS) go run -race ./cmd/app/
 
 tests:
 	go test -v -cover -race ./...
 
-run:
-	go run -race ./cmd/app/ --bottoken=$(BOT_TOKEN) --openaiapikey=$(OPENAI_API_KEY) --botusers=$(BOT_USERS)
-
-dc:
-	BOT_TOKEN=$(BOT_TOKEN) OPENAI_API_KEY=$(OPENAI_API_KEY) BOT_USERS=$(BOT_USERS) docker compose up -d
+docker:
+	BOT_TOKEN=$(BOT_TOKEN) OPENAI_API_KEY=$(OPENAI_API_KEY) BOT_USERS=$(BOT_USERS) docker compose down -v && docker compose up --build -d

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -47,7 +47,7 @@ func main() {
 	}
 
 	users := opts.BotUsers
-	log.Debug().Msgf("users: %s, len: %d", users, len(users))
+	log.Debug().Msgf("users: %v, len: %d", users, len(users))
 
 	updates := telegramBot.GetUpdatesChan()
 


### PR DESCRIPTION
- Add BOT_TOKEN, OPENAI_API_KEY, BOT_USERS to .env configuration
- Update Makefile to properly include environment variables